### PR TITLE
Fix surf_.json from previous PR merge

### DIFF
--- a/remote_data/surf_.json
+++ b/remote_data/surf_.json
@@ -455,7 +455,7 @@
         "Tier": 4,
         "Type": "Linear"
     },
-    "surf_simpsons_go_rc2_d": {
+    "surf_simpsons_cs2": {
         "Tier": 1,
         "Type": "Staged"
     },


### PR DESCRIPTION
Previous merged commit used "surf_simpsons_go_rc2_d". 

This has caused issues during map rotation whenever map is picked as well as improper records which are now set for removal (including points).

1. surf_simpsons_go_rc2_d does not exit.
2. surf_simpsons_go_rc2 exists, but is from 2016.
3. Intended new map was surf_simpsons_cs2.